### PR TITLE
feat(docker): Use default Docker random ports

### DIFF
--- a/src/resinci/docker.rb
+++ b/src/resinci/docker.rb
@@ -27,7 +27,7 @@ module Resinci
       end
 
       def run(name:, version:)
-        cmd="docker run -d --privileged -p $$:2375 %s \
+        cmd="docker run -d --privileged -P %s \
           -v #{CERT_PATH}:/mnt \
           --label io.resin.dev.dind=%s \
           library/docker:%s-dind docker daemon \


### PR DESCRIPTION
I think this is a cleaner way to do ports, and avoids the risk of conflicting with other services on the system.
